### PR TITLE
Add CI lint + format check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    name: Lint and format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Format check
+        run: yarn format:check


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `yarn lint` and `yarn format:check` on every PR and on pushes to `main`.
- Closes the gap where `git commit --no-verify` would silently bypass the husky hook — CI runs the same checks server-side so bypassed errors fail the PR.
- After this PR merges, the workflow's `quality` job will be added as a required status check on `main` so PRs cannot merge with lint/format errors.

## Test plan
- [ ] CI green on this PR (so we know the workflow itself works)
- [ ] After merge, add `quality` to required status checks on `main` (separate API call, no PR)
- [ ] Confirm Vercel deploy still passes (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)